### PR TITLE
fix: implement safe dereferencing for policy assignment properties in local and online MGs

### DIFF
--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-local/main.bicep
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-local/main.bicep
@@ -170,23 +170,25 @@ var allPolicySetDefinitions = [
 var allPolicyAssignments = [
   for policyAssignment in deduplicatedPolicyAssignments: {
     name: policyAssignment.name
-    description: policyAssignment.properties.description
-    displayName: policyAssignment.properties.displayName
+    displayName: policyAssignment.properties.?displayName
+    description: policyAssignment.properties.?description
     policyDefinitionId: policyAssignment.properties.policyDefinitionId
-    enforcementMode: policyAssignment.properties.enforcementMode
-    identity: policyAssignment.properties.identity
-    userAssignedIdentityId: policyAssignment.properties.userAssignedIdentity
-    roleDefinitionIds: policyAssignment.properties.roleDefinitionIds
-    parameters: policyAssignment.properties.parameters
-    nonComplianceMessages: policyAssignment.properties.nonComplianceMessages
-    metadata: policyAssignment.properties.metadata
-    overrides: policyAssignment.properties.overrides
-    resourceSelectors: policyAssignment.properties.resourceSelectors
+    parameters: policyAssignment.properties.?parameters
+    parameterOverrides: policyAssignment.properties.?parameterOverrides
+    identity: policyAssignment.identity.?type ?? 'None'
+    userAssignedIdentityId: policyAssignment.properties.?userAssignedIdentityId
+    roleDefinitionIds: policyAssignment.properties.?roleDefinitionIds
+    nonComplianceMessages: policyAssignment.properties.?nonComplianceMessages
+    metadata: policyAssignment.properties.?metadata
+    enforcementMode: policyAssignment.properties.?enforcementMode ?? 'Default'
+    notScopes: policyAssignment.properties.?notScopes
+    location: policyAssignment.?location
+    overrides: policyAssignment.properties.?overrides
+    resourceSelectors: policyAssignment.properties.?resourceSelectors
     definitionVersion: policyAssignment.properties.?definitionVersion
-    notScopes: policyAssignment.properties.notScopes
-    additionalManagementGroupsIDsToAssignRbacTo: policyAssignment.properties.additionalManagementGroupsIDsToAssignRbacTo
-    additionalSubscriptionIDsToAssignRbacTo: policyAssignment.properties.additionalSubscriptionIDsToAssignRbacTo
-    additionalResourceGroupResourceIDsToAssignRbacTo: policyAssignment.properties.additionalResourceGroupResourceIDsToAssignRbacTo
+    additionalManagementGroupsIDsToAssignRbacTo: policyAssignment.properties.?additionalManagementGroupsIDsToAssignRbacTo
+    additionalSubscriptionIDsToAssignRbacTo: policyAssignment.properties.?additionalSubscriptionIDsToAssignRbacTo
+    additionalResourceGroupResourceIDsToAssignRbacTo: policyAssignment.properties.?additionalResourceGroupResourceIDsToAssignRbacTo
   }
 ]
 

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-online/main.bicep
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-online/main.bicep
@@ -165,23 +165,25 @@ var allPolicySetDefinitions = [
 var allPolicyAssignments = [
   for policyAssignment in deduplicatedPolicyAssignments: {
     name: policyAssignment.name
-    description: policyAssignment.properties.description
-    displayName: policyAssignment.properties.displayName
+    displayName: policyAssignment.properties.?displayName
+    description: policyAssignment.properties.?description
     policyDefinitionId: policyAssignment.properties.policyDefinitionId
-    enforcementMode: policyAssignment.properties.enforcementMode
-    identity: policyAssignment.properties.identity
-    userAssignedIdentityId: policyAssignment.properties.userAssignedIdentity
-    roleDefinitionIds: policyAssignment.properties.roleDefinitionIds
-    parameters: policyAssignment.properties.parameters
-    nonComplianceMessages: policyAssignment.properties.nonComplianceMessages
-    metadata: policyAssignment.properties.metadata
-    overrides: policyAssignment.properties.overrides
-    resourceSelectors: policyAssignment.properties.resourceSelectors
+    parameters: policyAssignment.properties.?parameters
+    parameterOverrides: policyAssignment.properties.?parameterOverrides
+    identity: policyAssignment.identity.?type ?? 'None'
+    userAssignedIdentityId: policyAssignment.properties.?userAssignedIdentityId
+    roleDefinitionIds: policyAssignment.properties.?roleDefinitionIds
+    nonComplianceMessages: policyAssignment.properties.?nonComplianceMessages
+    metadata: policyAssignment.properties.?metadata
+    enforcementMode: policyAssignment.properties.?enforcementMode ?? 'Default'
+    notScopes: policyAssignment.properties.?notScopes
+    location: policyAssignment.?location
+    overrides: policyAssignment.properties.?overrides
+    resourceSelectors: policyAssignment.properties.?resourceSelectors
     definitionVersion: policyAssignment.properties.?definitionVersion
-    notScopes: policyAssignment.properties.notScopes
-    additionalManagementGroupsIDsToAssignRbacTo: policyAssignment.properties.additionalManagementGroupsIDsToAssignRbacTo
-    additionalSubscriptionIDsToAssignRbacTo: policyAssignment.properties.additionalSubscriptionIDsToAssignRbacTo
-    additionalResourceGroupResourceIDsToAssignRbacTo: policyAssignment.properties.additionalResourceGroupResourceIDsToAssignRbacTo
+    additionalManagementGroupsIDsToAssignRbacTo: policyAssignment.properties.?additionalManagementGroupsIDsToAssignRbacTo
+    additionalSubscriptionIDsToAssignRbacTo: policyAssignment.properties.?additionalSubscriptionIDsToAssignRbacTo
+    additionalResourceGroupResourceIDsToAssignRbacTo: policyAssignment.properties.?additionalResourceGroupResourceIDsToAssignRbacTo
   }
 ]
 


### PR DESCRIPTION
This pull request updates how policy assignment properties are accessed in the `main.bicep` files for both local and online landing zone management group modules. The changes make the property access safer and more robust by using optional chaining and providing default values where appropriate. This helps prevent errors when some properties are missing or undefined.

This aligns them with other management group modules that assign policies successfully today, such as corp etc. - these were just missed by mistake when making the fix previously

Key improvements to policy assignment property handling:

* Switched to optional property access (`.?`) for all policy assignment properties to handle missing or undefined values gracefully. [[1]](diffhunk://#diff-0c923121e9f04421913786672fedcc7ab938dbe9a522466a5a4e1be95fc5a9e8L173-R191) [[2]](diffhunk://#diff-13cbfab60d70ca2c98598726bec52ee156856872ca68542801abcd7d7782ead6L168-R186)
* Added default values for certain properties (e.g., `identity` defaults to `'None'`, `enforcementMode` defaults to `'Default'`) to ensure consistent behavior when those properties are not set. [[1]](diffhunk://#diff-0c923121e9f04421913786672fedcc7ab938dbe9a522466a5a4e1be95fc5a9e8L173-R191) [[2]](diffhunk://#diff-13cbfab60d70ca2c98598726bec52ee156856872ca68542801abcd7d7782ead6L168-R186)
* Included additional properties such as `parameterOverrides` and `location`, and updated how user-assigned identity IDs are accessed, improving the completeness and flexibility of policy assignment definitions. [[1]](diffhunk://#diff-0c923121e9f04421913786672fedcc7ab938dbe9a522466a5a4e1be95fc5a9e8L173-R191) [[2]](diffhunk://#diff-13cbfab60d70ca2c98598726bec52ee156856872ca68542801abcd7d7782ead6L168-R186)