### PR TITLE
fix: added RBAC for Connectivity Subscription Id for the policy Assignment Deploy-Private-DNS-Zones

### DIFF
--- a/templates/core/governance/mgmt-groups/decommissioned/main.bicep
+++ b/templates/core/governance/mgmt-groups/decommissioned/main.bicep
@@ -66,6 +66,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             contains(alzPolicyAssignmentRoleDefinitions, policyAssignment.name)
               ? {
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]

--- a/templates/core/governance/mgmt-groups/int-root/main.bicep
+++ b/templates/core/governance/mgmt-groups/int-root/main.bicep
@@ -299,6 +299,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             contains(alzPolicyAssignmentRoleDefinitions, policyAssignment.name)
               ? {
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]
@@ -465,4 +473,3 @@ module intRoot 'br/public:avm/ptn/alz/empty:0.3.6' = {
 // ================ //
 
 import { alzCoreType as alzCoreType } from '../../../alzCoreType.bicep'
-

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-corp/main.bicep
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-corp/main.bicep
@@ -77,6 +77,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             {
               policyDefinitionId: replace(
                 replace(

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-corp/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-corp/main.bicepparam
@@ -33,6 +33,7 @@ param landingZonesCorpConfig = {
 param parPolicyAssignmentParameterOverrides = {
   // Deploy-Private-DNS-Zones Policy: Configure private DNS zones for Azure services private endpoints
   'Deploy-Private-DNS-Zones': {
+    additionalSubscriptionIDsToAssignRbacTo: ['{{connectivity_subscription_id}}']
     parameters: {
       // Azure Container Registry private DNS zone
       azureAcrPrivateDnsZoneId: {

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-local/main.bicep
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-local/main.bicep
@@ -32,14 +32,11 @@ param parPolicyAssignmentParameterOverrides object = {}
 //   contributor: 'b24988ac-6180-42a0-ab88-20f7382dd24c'
 //   reader: 'acdd72a7-3385-48ef-bd42-f606fba81ae7'
 // }
-var alzRbacRoleDefsJson = [
-]
+var alzRbacRoleDefsJson = []
 
-var alzPolicyDefsJson = [
-]
+var alzPolicyDefsJson = []
 
-var alzPolicySetDefsJson = [
-]
+var alzPolicySetDefsJson = []
 
 var alzPolicyAssignmentsJson = [
   loadJsonContent('../../../lib/alz/landingzones/local/Enforce-ALDO-Services.alz_policy_assignment.json')
@@ -70,6 +67,14 @@ var alzPolicyAssignmentsWithOverrides = [
                     policyAssignment.properties.?parameters ?? {},
                     parPolicyAssignmentParameterOverrides[policyAssignment.name].parameters
                   )
+                }
+              : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
                 }
               : {},
             {
@@ -226,4 +231,3 @@ module landingZonesLocal 'br/public:avm/ptn/alz/empty:0.3.6' = {
 // ================ //
 
 import { alzCoreType as alzCoreType } from '../../../../alzCoreType.bicep'
-

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-online/main.bicep
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-online/main.bicep
@@ -67,6 +67,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             {
               policyDefinitionId: replace(
                 replace(

--- a/templates/core/governance/mgmt-groups/landingzones/main.bicep
+++ b/templates/core/governance/mgmt-groups/landingzones/main.bicep
@@ -224,6 +224,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             contains(alzPolicyAssignmentRoleDefinitions, policyAssignment.name)
               ? {
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]

--- a/templates/core/governance/mgmt-groups/platform/main.bicep
+++ b/templates/core/governance/mgmt-groups/platform/main.bicep
@@ -222,6 +222,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             contains(alzPolicyAssignmentRoleDefinitions, policyAssignment.name)
               ? {
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]

--- a/templates/core/governance/mgmt-groups/platform/platform-connectivity/main.bicep
+++ b/templates/core/governance/mgmt-groups/platform/platform-connectivity/main.bicep
@@ -68,6 +68,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             contains(alzPolicyAssignmentRoleDefinitions, policyAssignment.name)
               ? {
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]
@@ -236,4 +244,3 @@ module platformConnectivity 'br/public:avm/ptn/alz/empty:0.3.6' = {
 // ================ //
 
 import { alzCoreType as alzCoreType } from '../../../../alzCoreType.bicep'
-

--- a/templates/core/governance/mgmt-groups/platform/platform-identity/main.bicep
+++ b/templates/core/governance/mgmt-groups/platform/platform-identity/main.bicep
@@ -72,6 +72,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             contains(alzPolicyAssignmentRoleDefinitions, policyAssignment.name)
               ? {
                   roleDefinitionIds: alzPolicyAssignmentRoleDefinitions[policyAssignment.name]
@@ -240,4 +248,3 @@ module platformIdentity 'br/public:avm/ptn/alz/empty:0.3.6' = {
 // ================ //
 
 import { alzCoreType as alzCoreType } from '../../../../alzCoreType.bicep'
-

--- a/templates/core/governance/mgmt-groups/platform/platform-management/main.bicep
+++ b/templates/core/governance/mgmt-groups/platform/platform-management/main.bicep
@@ -56,6 +56,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             {
               policyDefinitionId: replace(
                 replace(

--- a/templates/core/governance/mgmt-groups/platform/platform-security/main.bicep
+++ b/templates/core/governance/mgmt-groups/platform/platform-security/main.bicep
@@ -56,6 +56,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             {
               policyDefinitionId: replace(
                 replace(

--- a/templates/core/governance/mgmt-groups/sandbox/main.bicep
+++ b/templates/core/governance/mgmt-groups/sandbox/main.bicep
@@ -58,6 +58,14 @@ var alzPolicyAssignmentsWithOverrides = [
                   )
                 }
               : {},
+            contains(
+                parPolicyAssignmentParameterOverrides[policyAssignment.name],
+                'additionalSubscriptionIDsToAssignRbacTo'
+              )
+              ? {
+                  additionalSubscriptionIDsToAssignRbacTo: parPolicyAssignmentParameterOverrides[policyAssignment.name].additionalSubscriptionIDsToAssignRbacTo
+                }
+              : {},
             {
               policyDefinitionId: replace(
                 replace(


### PR DESCRIPTION
Issue

The Deploy-Private-DNS-Zones policy deployed via Bicep (ALZ AVM) is not creating the required Network Contributor role assignment in the Connectivity subscription or the Private DNS zone resource group, causing remediation tasks to fail with permission errors.

Fix

Updated the Corp management group parameter parPolicyAssignmentParameterOverrides  to include additional Subscription Id for the policy assignment  Deploy-Private-DNS-Zones and update the variable alzPolicyAssignmentsWithOverrides with additional property additionalSubscriptionIDsToAssignRbacTo

## Related Issues/Work Items


https://github.com/Azure/Azure-Landing-Zones/issues/4151#issuecomment-4359426586


## This PR fixes/adds/changes/removes


Added RBAC for the Deploy-Private-DNS-Zones policy in the connectivity subscription to allow the managed identity to add records to private DNS zones.


### Breaking Changes

N/A

## Testing Evidence

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/alz-bicep-accelerator/pulls)
- [x] Associated it with relevant [GitHub Issues](https://github.com/Azure/alz-bicep-accelerator/issues)
- [ ] *(ALZ Bicep Core Team Only)* Associated it with relevant with `AB#` identifier [ADO Items](https://aka.ms/alz/bicep/backlog)
- [ ] Performed testing and provided evidence.
- [ ] Updated and/or created a separate PR as needed for documentation updates in [Azure Landing Zones docs](https://azure.github.io/Azure-Landing-Zones/bicep/)
