### PR TITLE
fix(hubnetworking): unique per-PIP domainNameLabel for active-active VPN gateway (#4141)

### DIFF
--- a/templates/networking/hubnetworking/main.bicep
+++ b/templates/networking/hubnetworking/main.bicep
@@ -618,11 +618,17 @@ module resVpnGateway 'br/public:avm/res/network/virtual-network-gateway:0.10.1' 
       enableDnsForwarding: hub.?vpnGatewaySettings.?enableDnsForwarding ?? false
       vpnGatewayGeneration: hub.?vpnGatewaySettings.?vpnGatewayGeneration ?? 'None'
       virtualNetworkResourceId: resHubVirtualNetwork[i].outputs.resourceId
+      // Active-active provisions two PIPs; supply a unique label per PIP to avoid the global cloudapp.azure.com default-label collision (issue #4141)
       domainNameLabel: !empty(hub.?vpnGatewaySettings.?domainNameLabel ?? [])
         ? hub.?vpnGatewaySettings.?domainNameLabel
-        : [
-            'vgw-alz-${hub.location}-${uniqueString(parHubNetworkingResourceGroupNamePrefix, hub.name, hub.location, 'vpn')}'
-          ]
+        : (hub.?vpnGatewaySettings.?vpnMode == 'activeActiveBgp' || hub.?vpnGatewaySettings.?vpnMode == 'activeActiveNoBgp')
+            ? [
+                'vgw-alz-${hub.location}-${uniqueString(parHubNetworkingResourceGroupNamePrefix, hub.name, hub.location, 'vpn', 'pip1')}'
+                'vgw-alz-${hub.location}-${uniqueString(parHubNetworkingResourceGroupNamePrefix, hub.name, hub.location, 'vpn', 'pip2')}'
+              ]
+            : [
+                'vgw-alz-${hub.location}-${uniqueString(parHubNetworkingResourceGroupNamePrefix, hub.name, hub.location, 'vpn')}'
+              ]
       publicIpAvailabilityZones: hub.?vpnGatewaySettings.?skuName != 'Basic'
         ? hub.?vpnGatewaySettings.?publicIpZones ?? publicIpRecommendedZones[i]
         : []


### PR DESCRIPTION
## Fixes #[4141](https://github.com/Azure/Azure-Landing-Zones/issues/4141)

### Problem
When the ALZ Bicep hub-networking starter deploys a VPN gateway in **active-active** mode (`vpnMode: 'activeActiveBgp'` or `'activeActiveNoBgp'`), deployment fails with:

```
The domain name label vgw-alz-<region>-pip1.<region>.cloudapp.azure.com is already reserved.
```

### Root cause
`resVpnGateway` in `templates/networking/hubnetworking/main.bicep` passes a `domainNameLabel` array with a **single** entry, but active-active mode provisions **two** public IPs. The second PIP falls back to the AVM module default `${gatewayName}-pip1` = `vgw-alz-<region>-pip1`, which is **not** tenant-seeded. Because `*.<region>.cloudapp.azure.com` is a global namespace, that default label collides across tenants — every user deploying active-active in a popular region hits it.

### Fix
Emit **one unique label per PIP** in active-active mode, each seeded with a distinct discriminator (`'pip1'` / `'pip2'`) plus the tenant-specific `parHubNetworkingResourceGroupNamePrefix`. Non-active-active and user-supplied `domainNameLabel` paths are unchanged.

### Validation (compiled ARM)
Both original and fixed templates compile cleanly (`az bicep build`, exit 0).

**Before** — single label for both PIPs:
```
createArray(format('vgw-alz-{0}-{1}', location, uniqueString(prefix, name, location, 'vpn')))
```

**After** — active-active emits two distinct, tenant-unique labels:
```
createArray(
  format('vgw-alz-{0}-{1}', location, uniqueString(prefix, name, location, 'vpn', 'pip1')),
  format('vgw-alz-{0}-{1}', location, uniqueString(prefix, name, location, 'vpn', 'pip2'))
)
```

- Tenant-unique: both labels include `parHubNetworkingResourceGroupNamePrefix`.
- Distinct per PIP: `uniqueString(…,'pip1') != uniqueString(…,'pip2')`.
- No regression: non-active-active branch is byte-for-byte the original single label; user-supplied `domainNameLabel` override still takes precedence.

### Notes
- A real active-active VPN gateway deployment is being run as end-to-end confirmation before merge.
