### PR TITLE
docs: add guidance for policy assignment parameter overrides

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,7 +9,7 @@ For help and questions about using this project, please raise an Issue.
 ## Microsoft Support Policy
 
 Support for this project is limited to the resources listed above.
-## Known limitations
+## Known Limitations
 
 ### Azure Government and Sovereign Clouds
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,3 +9,14 @@ For help and questions about using this project, please raise an Issue.
 ## Microsoft Support Policy
 
 Support for this project is limited to the resources listed above.
+## Known limitations
+
+### Azure Government and Sovereign Clouds
+
+This accelerator relies on Azure Policy built-in definitions and initiatives. Built-in policy versions available in Azure Government and other sovereign cloud environments may differ from those available in commercial Azure.
+
+### Policy Assignment Parameter Overrides
+
+The `parPolicyAssignmentParameterOverrides` parameter supports overriding policy assignment parameters only.
+
+Overriding built-in policy `definitionVersion` values is not supported. If a required built-in policy version is unavailable in the target cloud environment, use a supported version available in that environment or update to an ALZ Library release that references supported policy versions.

--- a/templates/core/governance/mgmt-groups/decommissioned/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/decommissioned/main.bicepparam
@@ -30,6 +30,9 @@ param decommissionedConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // Add parameter overrides here if needed for customization
 }

--- a/templates/core/governance/mgmt-groups/int-root/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/int-root/main.bicepparam
@@ -29,6 +29,9 @@ param intRootConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   'Deploy-MDFC-Config-H224': {
     parameters: {

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-corp/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-corp/main.bicepparam
@@ -30,6 +30,9 @@ param landingZonesCorpConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // Deploy-Private-DNS-Zones Policy: Configure private DNS zones for Azure services private endpoints
   'Deploy-Private-DNS-Zones': {

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-local/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-local/main.bicepparam
@@ -31,6 +31,9 @@ param landingZonesLocalConfig = {
 
 // Currently no policy assignments for local landing zones
 // When policies are added, specify parameter overrides here
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // No policy assignments in landing zones - local currently
 }

--- a/templates/core/governance/mgmt-groups/landingzones/landingzones-online/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/landingzones/landingzones-online/main.bicepparam
@@ -31,6 +31,9 @@ param landingZonesOnlineConfig = {
 
 // Currently no policy assignments for online landing zones
 // When policies are added, specify parameter overrides here
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // No policy assignments in landing zones - online currently
 }

--- a/templates/core/governance/mgmt-groups/landingzones/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/landingzones/main.bicepparam
@@ -30,6 +30,9 @@ param landingZonesConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   'Enable-DDoS-VNET': {
     parameters: {

--- a/templates/core/governance/mgmt-groups/platform/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/platform/main.bicepparam
@@ -30,6 +30,9 @@ param platformConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   'Deploy-VM-ChangeTrack': {
     parameters: {

--- a/templates/core/governance/mgmt-groups/platform/platform-connectivity/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/platform/platform-connectivity/main.bicepparam
@@ -30,6 +30,9 @@ param platformConnectivityConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   'Enable-DDoS-VNET': {
     parameters: {

--- a/templates/core/governance/mgmt-groups/platform/platform-identity/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/platform/platform-identity/main.bicepparam
@@ -30,6 +30,9 @@ param platformIdentityConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
     // No policy assignments in platform-identity currently
 }

--- a/templates/core/governance/mgmt-groups/platform/platform-management/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/platform/platform-management/main.bicepparam
@@ -30,6 +30,9 @@ param platformManagementConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // No policy assignments in platform-management currently
 }

--- a/templates/core/governance/mgmt-groups/platform/platform-security/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/platform/platform-security/main.bicepparam
@@ -30,6 +30,9 @@ param platformSecurityConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // No policy assignments in platform-security currently
 }

--- a/templates/core/governance/mgmt-groups/sandbox/main.bicepparam
+++ b/templates/core/governance/mgmt-groups/sandbox/main.bicepparam
@@ -30,6 +30,9 @@ param sandboxConfig = {
 }
 
 // Only specify the parameters you want to override - others will use defaults from JSON files
+// Supports policy assignment parameter overrides only.
+// Overriding built-in policy definitionVersion values is not supported.
+// See SUPPORT.md for known limitations and guidance.
 param parPolicyAssignmentParameterOverrides = {
   // Currently no common parameter overrides needed, but can be added here
 }


### PR DESCRIPTION
## Summary

Adds documentation and guidance for the policy definitionVersion override limitation identified during investigation of Issue #4213.

## Changes

- Added Known Limitations section to SUPPORT.md
- Documented Azure Government and sovereign cloud considerations
- Documented definitionVersion override limitation
- Added guidance comments above parPolicyAssignmentParameterOverrides in all template parameter files

## Impact

Documentation-only change.
No functional deployment behavior changes.